### PR TITLE
Re: 1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 **License:** GPLv2 or later  
 **License URI:** http://www.gnu.org/licenses/gpl-2.0.html  
 
-Automatically creates an user from a guest order in WooCommerce. Button to manually create an user from order details.
+Auto-creates users from guest WooCommerce orders. Adds manual user creation button. Maps existing orders to users on registration.
 
 ## Description
 
@@ -20,7 +20,9 @@ The "Create User From Guest Order" plugin automatically creates an user account 
 - Automatically creates an user account from a guest order.
 - Option to send a notification email to the newly created user.
 - Configurable settings in WooCommerce General settings tab.
-* NEW FEATURE: Button to manually create an user account from order details
+- NEW FEATURE: Button to manually create an user account from order details
+- NEW FEATURE: When a user register, check if they have any existing guest orders with the user email. If yes, link all the previous orders to the user.
+
 
 ## Installation
 
@@ -57,16 +59,18 @@ A: Yes, you can disable the notification email by unchecking the "Send User Noti
 
 ## Changelog
 
-### 1.0.1 (2024-11-30)
+### 1.0.1 (2024-12-13)
 - Improvement: Manually create user from order details.
 - Improvement: At plugins page, added a direct link to our settings page.
+- Improvement: When a user register, check if they have any existing guest orders with the user email. If yes, link all the previous orders to the user.
+
 
 ### 1.0
 - Initial release.
 
 ## Upgrade Notice
 
-### 1.0.1 (2024-11-30)
+### 1.0.1 (2024-12-13)
 * Improvements: upgrade safe, no breaking changes.
 
 ### 1.0
@@ -80,4 +84,3 @@ This plugin is licensed under the GPLv2 or later. For more information, see [GPL
 
 **Author:** S.Aziz Khan  
 **Author URI:** [https://github.com/s-azizkhan](https://github.com/s-azizkhan)
-

--- a/create-user-from-guest-order.php
+++ b/create-user-from-guest-order.php
@@ -26,7 +26,7 @@ if (!defined('WPINC')) {
     die;
 }
 
-define("CUFGO_VERSION", "1.0");
+define("CUFGO_VERSION", "1.0.1");
 
 class CUFGO_User_From_Guest_Order
 {
@@ -74,9 +74,15 @@ class CUFGO_User_From_Guest_Order
      *
      * @param array $settings
      * @return array
+     * @version 1.0.1
      */
     public function createUserFromGuestOrderSettings($settings)
     {
+        // check for permission
+        if(!current_user_can('manage_woocommerce')) {
+            return $settings;
+        }
+
         $settings[] = array(
             'title' => __('Create User From Guest Order', 'create-user-from-guest-order'),
             'desc' => __('Map existing user to guest order or Create new user while creating/updating guest order, ( Billing email used in validation ) imp: This will work when order created by Admin', 'create-user-from-guest-order'),
@@ -113,12 +119,13 @@ class CUFGO_User_From_Guest_Order
      * Create user from guest order
      *
      * @param int $order_id
+     * @version 1.0.1
      */
     public function createUserFromGuestOrder($order_id)
     {
         try {
             // Check if the feature is enabled and continue
-            if (self::isFeatureEnabled() && is_admin()) {
+            if (self::isFeatureEnabled()) {
                 $order = wc_get_order($order_id);
                 //get customer ID
                 $customer_id = $order->get_customer_id();

--- a/create-user-from-guest-order.php
+++ b/create-user-from-guest-order.php
@@ -12,7 +12,7 @@
  * Plugin Name:       Create User From Guest Order
  * Plugin URI:        https://github.com/s-azizkhan/create-user-from-guest-order-wp-plugin
  * Description:       Automatically creates a user from a guest order in WooCommerce.
- * Version:           1.0.0
+ * Version:           1.0.1
  * Author:            Aziz Khan
  * Author URI:        https://github.com/s-azizkhan
  * License:           GPL-2.0+

--- a/readme.txt
+++ b/readme.txt
@@ -9,7 +9,7 @@ Stable tag: 1.0.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
-Automatically creates an user from a guest order in WooCommerce. Button to manually create an user from order details.
+Auto-creates users from guest WooCommerce orders. Adds manual user creation button. Maps existing orders to users on registration.
 
 == Description ==
 
@@ -21,6 +21,7 @@ The "Create User From Guest Order" plugin automatically creates an user account 
 * Option to send a notification email to the newly created user.
 * Configurable settings in WooCommerce General settings tab.
 * NEW FEATURE: Button to manually create an user account from order details.
+* NEW FEATURE: When a user register, check if they have any existing guest orders with the user email. If yes, link all the previous orders to the user.
 
 == Installation ==
 
@@ -56,16 +57,17 @@ Yes, you can disable the notification email by unchecking the "Send User Notific
 
 == Changelog ==
 
-= 1.0.1 2024-11-30 =
+= 1.0.1 2024-12-13 =
 * Improvement: Manually create user from order details.
 * Improvement: At plugins page, added a direct link to our settings page.
+* Improvement: When a user register, check if they have any existing guest orders with the user email. If yes, link all the previous orders to the user.
 
 = 1.0 =
 * Initial release.
 
 == Upgrade Notice ==
 
-= 1.0.1 2024-11-30 =
+= 1.0.1 2024-12-13 =
 * Improvements: upgrade safe, no breaking changes.
 
 = 1.0 =


### PR DESCRIPTION
- feat: links past orders when a new account is registered
- check for permission while register settings in woocommerce
- enable guest order mapping for non admin order too.